### PR TITLE
style: 전역 스타일 추가

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,24 @@ theme:
   name: material
   custom_dir: overrides
   language: kr
+  font:
+    text: "Noto Sans KR"
   palette:
-    primary: "deep orange"
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep orange
+      toggle:
+        icon: material/weather-night
+        name: 다크모드로 전환
+
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep orange
+      toggle:
+        icon: material/weather-sunny
+        name: 일반모드로 전환
   features:
     - navigation.sections
     - navigation.expand
@@ -36,7 +52,7 @@ plugins:
       timezone: Asia/Seoul
       locale: ko
       fallback_to_build_date: false
-  - git-authors  
+  - git-authors
   - macros
 copyright: |
   <strong>&copy; 2021 <a href="https://dotnetdev.kr/" target="_blank">.NET DEV</a>, All rights reserved.</strong>


### PR DESCRIPTION
기본 폰트(`Noto Sans`)와 다크테마를 추가했습니다.

### 폰트 적용 전

<img width="811" alt="폰트적용 전" src="https://user-images.githubusercontent.com/10791961/115139677-2efb4d00-a06e-11eb-95cf-0dad4d6e8f6d.png">

### 폰트 적용 후

<img width="811" alt="폰트적용 후" src="https://user-images.githubusercontent.com/10791961/115139683-37538800-a06e-11eb-8db8-00b63f040e08.png">


### 다크테마 적용 후

<img width="812" alt="다크모드" src="https://user-images.githubusercontent.com/10791961/115139689-3e7a9600-a06e-11eb-9a50-94c424c5ca8b.png">
